### PR TITLE
Change sorting for assemble-authors.

### DIFF
--- a/ghizmo/commands/authors.py
+++ b/ghizmo/commands/authors.py
@@ -53,8 +53,8 @@ def assemble_authors(config, args):
 
   yield lib.status("Read %s authors" % len(author_list))
 
-  # Sort alphabetically by login.
-  author_list.sort(key=lambda (login, user, role): login.lower())
+  # Sort alphabetically by login, with assigned roles grouped first.
+  author_list.sort(key=lambda (login, user, role): ((0 if role else 1), login.lower()))
 
   def format_user(login, name):
     if login and name:

--- a/ghizmo/main.py
+++ b/ghizmo/main.py
@@ -16,7 +16,7 @@ import argparse
 from commands.lib import to_bool
 
 NAME = "ghizmo"
-VERSION = "0.1.11"
+VERSION = "0.1.12"
 DESCRIPTION = "ghizmo: An extensible command line for GitHub"
 LONG_DESCRIPTION = __doc__
 


### PR DESCRIPTION
Seems like this sorting is generally preferable and OK by default, as we need to see roles of people quickly. Decided against sorting by role as that is a bit messy.